### PR TITLE
Fix microdata to properly use schema.org vocab.

### DIFF
--- a/templates/movie.html
+++ b/templates/movie.html
@@ -2,33 +2,31 @@
 <link rel="alternate" type="application/json" href="{{ request.path }}.json">
 <title>{{ movie.title }}</title>
 
-<body itemscope itemtype="https://schema.org/Movie"
-                vocab="http://schema.org/"
-                prefix="helpdesk:https://rawgit.com/sils-webinfo/helpdesk/master/vocab.ttl#"
-                typeof="movietheater:Movie">
+<body id="movie" itemprop="workPresented" itemscope itemtype="https://schema.org/Movie">
 
 
 <a href="http://getschema.org/microdataextractor?url={{ request.url }}&out=json">
 view data extracted from microdata markup</a><br>  
 
 
-<h1 class="title" itemprop="name" property="name">{{ movie.title }}</h1>
+<h1 itemprop="name">{{ movie.title }}</h1>
 
-<h3 class="director" itemprop="description" property="description"> Directed by: {{ movie.director }}</h3>
+<h3 itemprop="director" itemscope itemtype="https://schema.org/Person">
+  Directed by: <span itemprop="name">{{ movie.director }}</span>
+</h3>
 
-<p class="rating" itemprop="description" property="description"><b>Rated:</b> {{ movie.rating }}</p>
+<p><b>Rated:</b> <span itemprop="contentRating">{{ movie.rating }}</span></p>
 
-<p class="licence" itemprop="description" property="description"><b>Licenced?</b> {{ movie.licence }}</p>
+<p class="licence"><b>Licenced?</b> {{ movie.licence }}</p>
 
-<p class="duration" itemprop="description" property="description"><b>Duration:</b> {{ movie.duration }}</p>
+<p><b>Duration:</b> <span itemprop="duration">{{ movie.duration }}</span></p>
 
-<p class="description" itemprop="decsription" property="description"><b>Description:</b> {{ movie.description }}</p>
+<p><b>Description:</b> <span itemprop="description">{{ movie.description }}</span></p>
 
 <ul>
       {% for showing in movie.showing %}
-      <li itemprop="showing" itemscope itemtype="http://schema.org/startTime"
-          property="showing" typeof="showing">
-        <p itemprop="text" property="text"><a href="/showings.html" rel="related">{{ showing }}</a></p>
+      <li itemscope itemtype="http://schema.org/ScreeningEvent" itemref="movie">
+        <a href="/showings.html"><span itemprop="doorTime">{{ showing }}</span></a>
       </li>
       {% endfor %}
     </ul>

--- a/templates/movielist.html
+++ b/templates/movielist.html
@@ -19,16 +19,10 @@ view data extracted from microdata markup</a><br>
 <ol>
   {% for movie_id, movie in movielist %}
   <li itemscope
-      itemid="{{ url_for('movie', movie_id=movie_id, _external=True) }}"
-      resource="{{ url_for('movie', movie_id=movie_id, _external=True) }}"
-      vocab="http://schema.org/"
-      prefix="helpdesk: https://rawgit.com/sils-webinfo/helpdesk/master/vocab.ttl#"
-      property="movietheater:movielist"
-      typeof="movietheater:Movie">
-    <!-- <div itemprop="http://www.w3.org/ns/md#item"
-         itemscope itemtype="http://schema.org/CreativeWork/HelpRequest"> -->
+      itemtype="http://schema.org/Movie"
+      itemid="{{ url_for('movie', movie_id=movie_id, _external=True) }}">
     <a href="{{ url_for('movie', movie_id=movie_id) }}" rel="item">
-      <span itemprop="name" property="name">{{ movie.title }}</span>
+      <span itemprop="name">{{ movie.title }}</span>
     </a>
      rating:  {{movie.rating }}
         licence: {{ movie.licence }}


### PR DESCRIPTION
This patch fixes your templates to use the appropriate schema.org properties, and to properly list showtimes as schema.org [ScreeningEvents](http://schema.org/ScreeningEvent).